### PR TITLE
Solution for Deep copy, used Reflect.ownKeys for the first time

### DIFF
--- a/js-exercises/deep-copy-object/README.md
+++ b/js-exercises/deep-copy-object/README.md
@@ -1,0 +1,9 @@
+# Instructions
+
+Implement a method `deepCopyObject` which returns a deep copy of a given object.
+
+Give an option in the parameter to copy the descriptors as well.
+
+## Restrictions
+
+- Don't use `JSON.parse`, `eval`, or `Function`.

--- a/js-exercises/deep-copy-object/deepCopyObject.js
+++ b/js-exercises/deep-copy-object/deepCopyObject.js
@@ -1,0 +1,18 @@
+const deepCopyObject = (objToCopy) => {
+  if (objToCopy == null || typeof objToCopy !== 'object') {
+    return objToCopy;
+  }
+  const newCopiedObject = objToCopy.constructor();
+
+  for (const attr of Reflect.ownKeys(objToCopy)) {
+    if (typeof objToCopy[attr] === 'object') {
+      newCopiedObject[attr] = deepCopyObject(objToCopy[attr]);
+    } else {
+      newCopiedObject[attr] = objToCopy[attr];
+    }
+  }
+
+  return newCopiedObject;
+};
+
+export { deepCopyObject };

--- a/js-exercises/deep-copy-object/deepCopyObject.test.js
+++ b/js-exercises/deep-copy-object/deepCopyObject.test.js
@@ -1,0 +1,45 @@
+import { deepCopyObject } from './deepCopyObject';
+
+describe('deepCopyObject', () => {
+  it('returns a deep copy of given object', () => {
+    const myObj = {
+      subObj: {
+        key: 'value',
+      },
+    };
+
+    const yourObj = deepCopyObject(myObj);
+
+    yourObj.subObj.key = 'new value';
+
+    expect(yourObj.subObj.key).toEqual('new value');
+    expect(myObj.subObj.key).toEqual('value');
+  });
+
+  it('returns a deep copy of given object with nesting level 2', () => {
+    const myObj = {
+      subObj: {
+        key: 'value',
+      },
+      nestObj: {
+        key1: {
+          key2: 'birth-value',
+        },
+      },
+    };
+
+    const yourObj = deepCopyObject(myObj);
+
+    yourObj.nestObj.key1.key2 = 'death-value';
+
+    expect(yourObj.nestObj.key1.key2).toEqual('death-value');
+    expect(myObj.nestObj.key1.key2).toEqual('birth-value');
+  });
+
+  it('returns copy of other data types', () => {
+    expect(deepCopyObject(4)).toEqual(4);
+    expect(deepCopyObject('string!')).toEqual('string!');
+    expect(deepCopyObject(true)).toBe(true);
+    expect(deepCopyObject(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Tried a solution to combine Object.getOwnPropertyNames and Object.getOwnPropertySymbols and used Reflect.ownKeys. Kindly help with your comments whether this is a right fit for this requirement. Thanks!